### PR TITLE
Add GITHUB_PATH support to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,13 +106,19 @@ for bin in sair-device-source sair-proxy sair-acquire sair-release; do
     fi
 done
 
-# Check PATH
+# Ensure INSTALL_DIR is in PATH
 case ":${PATH}:" in
     *":${INSTALL_DIR}:"*) ;;
     *)
-        echo ""
-        echo "NOTE: ${INSTALL_DIR} is not in your PATH. Add it with:"
-        echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+        if [[ -n "${GITHUB_PATH:-}" ]]; then
+            echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+            echo ""
+            echo "Added ${INSTALL_DIR} to GITHUB_PATH."
+        else
+            echo ""
+            echo "NOTE: ${INSTALL_DIR} is not in your PATH. Add it with:"
+            echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+        fi
         ;;
 esac
 


### PR DESCRIPTION
## Summary
- When running in GitHub Actions, automatically adds the install directory to `$GITHUB_PATH`
- This makes `sair-acquire` and `sair-release` available in subsequent workflow steps without manual PATH setup
- Outside CI, the existing "NOTE: add to PATH" message is shown as before

## Context
The install script puts tools in `~/.local/bin` by default, which isn't in PATH on the GitHub Actions runner Docker containers. This caused `sair-acquire: command not found` in downstream repos that switched from vendored tools to `install.sh`.

## Test plan
- [ ] Verify tools are in PATH in subsequent steps on self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)