### PR TITLE
Remove abb/abb_exec from features to fix install deadlock

### DIFF
--- a/internal/proxy/adb_connection.go
+++ b/internal/proxy/adb_connection.go
@@ -139,8 +139,12 @@ func (c *AdbConnection) handleHostCommand(request string) {
 
 	case request == "host:features" || request == "host:host-features" ||
 		(strings.HasPrefix(request, "host-serial:") && strings.HasSuffix(request, ":features")):
+		// Do not advertise abb or abb_exec — the proxy cannot handle these
+		// natively, so they fall through to ForwardToDevice which can deadlock.
+		// Without these features ddmlib falls back to shell:pm ... which the
+		// proxy handles via ExecOnDevice.
 		c.writeOkayWithPayload(
-			"cmd,stat_v2,ls_v2,fixed_push_mkdir,apex,abb,fixed_push_symlink_timestamp,abb_exec,remount_shell,track_app,sendrecv_v2,sendrecv_v2_brotli,sendrecv_v2_lz4,sendrecv_v2_zstd,sendrecv_v2_dry_run_send,openscreen_mdns")
+			"cmd,stat_v2,ls_v2,fixed_push_mkdir,apex,fixed_push_symlink_timestamp,remount_shell,track_app,sendrecv_v2,sendrecv_v2_brotli,sendrecv_v2_lz4,sendrecv_v2_zstd,sendrecv_v2_dry_run_send,openscreen_mdns")
 
 	case request == "host:devices" || request == "host:devices-short":
 		devices := c.getVisibleDevices()


### PR DESCRIPTION
## Summary
- The proxy advertised `abb` and `abb_exec` in its feature response, causing ddmlib to use `abb_exec:package install-create` instead of `shell:pm install-create`
- Since the proxy doesn't handle `abb_exec:` natively, these commands fell through to `ForwardToDevice`'s bidirectional gRPC tunnel, which deadlocks under backpressure (observed as 4-minute hangs in CI)
- Removing these features makes ddmlib fall back to `shell:pm` commands, which the proxy handles reliably via `ExecOnDevice`

Follow-up to #11 — the shell,v2 fix was correct but the actual hang was caused by `abb_exec:`, not `shell,v2:`.

Closes #10

## Test plan
- [x] All existing tests pass
- [ ] Deploy and verify `connectedCheck` no longer hangs on `pm install-create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)