### PR TITLE
Merge PR #13 (architecture fixes) into main

### DIFF
--- a/cmd/sair-device-source/main.go
+++ b/cmd/sair-device-source/main.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/compscidr/sair/internal/devicesource"
 	"github.com/compscidr/sair/internal/updater"
@@ -15,6 +19,7 @@ import (
 	pb "github.com/compscidr/sair/proto/devicesource"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func main() {
@@ -29,15 +34,40 @@ func main() {
 		}
 	}
 
+	proxyAddr := os.Getenv("PROXY_ADDR")
+	if proxyAddr == "" {
+		proxyAddr = "http://localhost:8550"
+	}
+
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		slog.Error("failed to listen", "error", err)
 		os.Exit(1)
 	}
 
-	server := grpc.NewServer()
-	pb.RegisterDeviceSourceServer(server, devicesource.NewServer())
+	dsServer := devicesource.NewServer()
+	server := grpc.NewServer(
+		grpc.MaxRecvMsgSize(64*1024*1024),
+		grpc.MaxSendMsgSize(64*1024*1024),
+		grpc.InitialWindowSize(16*1024*1024),
+		grpc.InitialConnWindowSize(16*1024*1024),
+	)
+	pb.RegisterDeviceSourceServer(server, dsServer)
 	reflection.Register(server)
+
+	// Determine our address for the proxy to connect back for commands
+	sourceAddr := os.Getenv("DEVICE_SOURCE_ADDR")
+	if sourceAddr == "" {
+		sourceAddr = fmt.Sprintf("localhost:%d", port)
+	}
+
+	// Start device reporter — pushes device list to proxy
+	apiKey := os.Getenv("SAIR_API_KEY")
+	if apiKey == "" {
+		apiKey = "dev-key-123"
+	}
+	stopReport := make(chan struct{})
+	go reportDevices(dsServer, proxyAddr, sourceAddr, apiKey, stopReport)
 
 	// Graceful shutdown
 	sigCh := make(chan os.Signal, 1)
@@ -45,12 +75,93 @@ func main() {
 	go func() {
 		<-sigCh
 		slog.Info("shutting down gRPC server")
+		close(stopReport)
 		server.GracefulStop()
 	}()
 
-	slog.Info("DeviceSource server listening", "port", port)
+	slog.Info("DeviceSource server listening", "port", port, "proxy", proxyAddr)
 	if err := server.Serve(lis); err != nil {
 		slog.Error("server failed", "error", err)
 		os.Exit(1)
+	}
+}
+
+type deviceReport struct {
+	SourceAddr string       `json:"source_addr"`
+	Devices    []deviceInfo `json:"devices"`
+}
+
+type deviceInfo struct {
+	Serial       string `json:"serial"`
+	Manufacturer string `json:"manufacturer"`
+	Model        string `json:"model"`
+	Sdk          int32  `json:"sdk"`
+	Release      int32  `json:"release"`
+}
+
+func reportDevices(dsServer *devicesource.Server, proxyAddr, sourceAddr, apiKey string, stop chan struct{}) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	report := func() {
+		devices, err := dsServer.GetDevices(nil, &emptypb.Empty{})
+		if err != nil {
+			slog.Warn("failed to get local devices", "error", err)
+			return
+		}
+
+		var infos []deviceInfo
+		for _, d := range devices.Devices {
+			infos = append(infos, deviceInfo{
+				Serial:       d.Serial,
+				Manufacturer: d.Manufacturer,
+				Model:        d.Model,
+				Sdk:          d.Sdk,
+				Release:      d.Release,
+			})
+		}
+
+		body, err := json.Marshal(deviceReport{
+			SourceAddr: sourceAddr,
+			Devices:    infos,
+		})
+		if err != nil {
+			slog.Warn("failed to marshal device report", "error", err)
+			return
+		}
+
+		req, err := http.NewRequest("POST", proxyAddr+"/internal/devices", bytes.NewReader(body))
+		if err != nil {
+			slog.Warn("failed to create request", "error", err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", apiKey)
+		resp, err := client.Do(req)
+		if err != nil {
+			slog.Warn("failed to report devices to proxy", "error", err)
+			return
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			slog.Warn("proxy rejected device report", "status", resp.StatusCode)
+			return
+		}
+
+		slog.Info("reported devices to proxy", "count", len(infos), "proxy", proxyAddr)
+	}
+
+	// Report immediately on startup
+	report()
+
+	for {
+		select {
+		case <-ticker.C:
+			report()
+		case <-stop:
+			return
+		}
 	}
 }

--- a/cmd/sair-proxy/main.go
+++ b/cmd/sair-proxy/main.go
@@ -40,9 +40,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	deviceListTracker := proxy.NewDeviceListTracker(commandRouter, 5000)
+	deviceListTracker := proxy.NewDeviceListTracker(commandRouter)
 	scopedPortManager := proxy.NewScopedPortManager(commandRouter, deviceListTracker, heartbeatInterval)
-	httpAPI := proxy.NewHTTPApi(scopedPortManager, apiKey, httpAPIPort, httpAPIHost)
+	httpAPI := proxy.NewHTTPApi(scopedPortManager, deviceListTracker, apiKey, httpAPIPort, httpAPIHost)
 
 	adbProxy := proxy.NewAdbProxy(port, commandRouter, deviceListTracker)
 

--- a/internal/devicesource/server.go
+++ b/internal/devicesource/server.go
@@ -268,17 +268,21 @@ func (s *Server) ForwardToDevice(stream pb.DeviceSource_ForwardToDeviceServer) e
 	}
 	slog.Debug("ForwardToDevice: transport established", "serial", setup.Serial)
 
-	// Send the initial command (e.g., "sync:")
-	if err := sendAdbLtv(conn, setup.InitialCommand); err != nil {
-		conn.Close()
-		return status.Errorf(codes.Internal, "failed to send initial command: %v", err)
+	// Send the initial command if provided (e.g., "sync:").
+	// When empty, the proxy is tunneling everything after transport — the
+	// client's next message will be the command, relayed through the tunnel.
+	if setup.InitialCommand != "" {
+		if err := sendAdbLtv(conn, setup.InitialCommand); err != nil {
+			conn.Close()
+			return status.Errorf(codes.Internal, "failed to send initial command: %v", err)
+		}
+		slog.Debug("ForwardToDevice: initial command sent", "serial", setup.Serial, "command", setup.InitialCommand)
 	}
-	slog.Debug("ForwardToDevice: initial command sent", "serial", setup.Serial, "command", setup.InitialCommand)
 
 	// Bidirectional forwarding
-	done := make(chan error, 2)
+	done := make(chan error, 1)
 
-	// ADB → gRPC
+	// ADB → gRPC (response direction — drives teardown)
 	go func() {
 		buf := make([]byte, 32768)
 		for {
@@ -301,34 +305,44 @@ func (s *Server) ForwardToDevice(stream pb.DeviceSource_ForwardToDeviceServer) e
 		}
 	}()
 
-	// gRPC → ADB
+	// gRPC → ADB (request direction — half-close aware)
 	go func() {
 		for {
 			msg, err := stream.Recv()
 			if err != nil {
-				slog.Debug("ForwardToDevice: gRPC recv done", "serial", setup.Serial, "error", err)
-				done <- err
+				slog.Info("ForwardToDevice: gRPC recv done", "serial", setup.Serial, "error", err)
+				if err == io.EOF {
+					// Client done sending — half-close the ADB write side so ADB
+					// knows all data has arrived, but keep the read side open for
+					// the response (e.g. exec: install-write result).
+					if tc, ok := conn.(*net.TCPConn); ok {
+						slog.Info("ForwardToDevice: half-closing ADB write side", "serial", setup.Serial)
+						tc.CloseWrite()
+					}
+				} else {
+					// Real error — close conn to unblock the response direction.
+					conn.Close()
+				}
 				return
 			}
 			if data := msg.GetData(); data != nil {
 				slog.Debug("ForwardToDevice: gRPC→ADB", "serial", setup.Serial, "bytes", len(data))
 				if _, err := conn.Write(data); err != nil {
-					slog.Debug("ForwardToDevice: ADB write failed", "serial", setup.Serial, "error", err)
-					done <- err
+					slog.Info("ForwardToDevice: ADB write failed", "serial", setup.Serial, "error", err)
+					conn.Close()
 					return
 				}
 			}
 		}
 	}()
 
-	// Wait for either direction to finish, then close the ADB connection
-	// to unblock the other goroutine.
+	// Wait for the response direction to finish, then close the ADB connection
+	// and return. Returning from the method causes the gRPC framework to cancel
+	// the stream, which unblocks the request goroutine's stream.Recv().
 	err = <-done
 	conn.Close()
-	err2 := <-done
 
-	// Return the first real error (prefer non-EOF/non-canceled).
-	resultErr := firstRealError(err, err2)
+	resultErr := firstRealError(err)
 	slog.Info("ForwardToDevice: finished", "serial", setup.Serial, "error", resultErr)
 	return resultErr
 }

--- a/internal/proxy/adb_connection.go
+++ b/internal/proxy/adb_connection.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -12,29 +11,18 @@ import (
 	pb "github.com/compscidr/sair/proto/orchestrator"
 )
 
-type connectionMode int
-
-const (
-	hostMode      connectionMode = iota
-	transportMode
-)
-
 // AdbConnection handles a single ADB client TCP connection.
 //
-// Implements the state machine:
-//
-//	HOST_MODE → (host:transport:<serial>) → TRANSPORT_MODE
+// Host-mode commands (version, devices, transport selection) are handled
+// locally. Once the client selects a transport, all subsequent traffic is
+// tunneled transparently to the real ADB server through the device-source.
 type AdbConnection struct {
 	conn              net.Conn
 	commandRouter     *CommandRouter
 	deviceListTracker *DeviceListTracker
 	allowedSerials    map[string]struct{} // nil = all, empty = none
 
-	mode            connectionMode
-	transportSerial string
-	keepAlive       bool
-	connCtx         context.Context
-	connCancel      context.CancelFunc
+	keepAlive bool
 }
 
 func NewAdbConnection(
@@ -48,16 +36,13 @@ func NewAdbConnection(
 		commandRouter:     commandRouter,
 		deviceListTracker: deviceListTracker,
 		allowedSerials:    allowedSerials,
-		mode:              hostMode,
 	}
 }
 
 func (c *AdbConnection) Handle() {
-	c.connCtx, c.connCancel = context.WithCancel(context.Background())
 	remoteAddr := c.conn.RemoteAddr()
 	slog.Info("new ADB connection", "remote", remoteAddr)
 	defer func() {
-		c.connCancel()
 		c.conn.Close()
 		slog.Debug("ADB connection closed", "remote", remoteAddr)
 	}()
@@ -71,14 +56,8 @@ func (c *AdbConnection) Handle() {
 			return
 		}
 
-		switch c.mode {
-		case hostMode:
-			c.handleHostCommand(request)
-			if !c.keepAlive {
-				return
-			}
-		case transportMode:
-			c.handleTransportCommand(request)
+		c.handleHostCommand(request)
+		if !c.keepAlive {
 			return
 		}
 	}
@@ -210,7 +189,6 @@ func (c *AdbConnection) handleHostCommand(request string) {
 		slog.Info("received host:kill — ignoring (proxy stays running)")
 
 	case strings.HasPrefix(request, "host:transport:"):
-		c.keepAlive = true
 		serial := strings.TrimPrefix(request, "host:transport:")
 		if !c.isSerialAllowed(serial) {
 			c.writeFail("device " + serial + " not available — use sair-acquire")
@@ -219,7 +197,6 @@ func (c *AdbConnection) handleHostCommand(request string) {
 		c.handleTransport(serial)
 
 	case request == "host:transport-any":
-		c.keepAlive = true
 		devices := c.getVisibleDevices()
 		if len(devices) == 0 {
 			c.writeFail("no devices available — use sair-acquire")
@@ -228,7 +205,6 @@ func (c *AdbConnection) handleHostCommand(request string) {
 		c.handleTransport(devices[0].Serial)
 
 	case strings.HasPrefix(request, "host:tport:serial:"):
-		c.keepAlive = true
 		serial := strings.TrimPrefix(request, "host:tport:serial:")
 		if !c.isSerialAllowed(serial) {
 			c.writeFail("device " + serial + " not available — use sair-acquire")
@@ -237,7 +213,6 @@ func (c *AdbConnection) handleHostCommand(request string) {
 		c.handleTransportWithID(serial)
 
 	case request == "host:tport:any":
-		c.keepAlive = true
 		devices := c.getVisibleDevices()
 		if len(devices) == 0 {
 			c.writeFail("no devices available — use sair-acquire")
@@ -246,7 +221,6 @@ func (c *AdbConnection) handleHostCommand(request string) {
 		c.handleTransportWithID(devices[0].Serial)
 
 	case strings.HasPrefix(request, "host:transport-id:"):
-		c.keepAlive = true
 		idStr := strings.TrimPrefix(request, "host:transport-id:")
 		transportID := 0
 		fmt.Sscanf(idStr, "%d", &transportID)
@@ -314,8 +288,6 @@ func (c *AdbConnection) handleHostCommand(request string) {
 }
 
 func (c *AdbConnection) handleTransportWithID(serial string) {
-	c.transportSerial = serial
-	c.mode = transportMode
 	c.writeOkay()
 
 	// tport protocol: send transport ID as 8-byte little-endian after OKAY
@@ -324,54 +296,22 @@ func (c *AdbConnection) handleTransportWithID(serial string) {
 	binary.LittleEndian.PutUint64(buf, uint64(transportID))
 	if _, err := c.conn.Write(buf); err != nil {
 		slog.Error("failed to write transport ID", "serial", serial, "error", err)
+		return
 	}
-	slog.Debug("transport (tport)", "serial", serial, "transportID", transportID)
+	slog.Debug("transport (tport) — starting tunnel", "serial", serial, "transportID", transportID)
+
+	// Tunnel all subsequent traffic to the real ADB server through device-source.
+	if err := c.commandRouter.ForwardToDevice(serial, "", c.conn); err != nil {
+		slog.Error("tunnel failed", "serial", serial, "error", err)
+	}
 }
 
 func (c *AdbConnection) handleTransport(serial string) {
-	c.transportSerial = serial
-	c.mode = transportMode
 	c.writeOkay()
-	slog.Debug("transport", "serial", serial)
-}
+	slog.Debug("transport — starting tunnel", "serial", serial)
 
-func (c *AdbConnection) handleTransportCommand(request string) {
-	slog.Debug("TRANSPORT command", "serial", c.transportSerial, "request", request)
-
-	switch {
-	case strings.HasPrefix(request, "shell:"):
-		command := strings.TrimPrefix(request, "shell:")
-		c.writeOkay()
-
-		if err := c.commandRouter.ExecuteOnDevice(c.connCtx, c.transportSerial, command, func(data []byte) error {
-			return WriteRaw(c.conn, data)
-		}); err != nil {
-			slog.Error("shell command failed", "serial", c.transportSerial, "error", err)
-		}
-
-	case strings.HasPrefix(request, "shell,"):
-		// shell,v2,TERM=xterm-256color:<command> — used by modern ddmlib/AGP.
-		// Route through ExecOnDevice with v2 framing instead of ForwardToDevice
-		// to avoid bidirectional gRPC tunneling that can deadlock.
-		colonIdx := strings.Index(request, ":")
-		if colonIdx < 0 {
-			c.writeFail("malformed shell,v2 command")
-			return
-		}
-		command := request[colonIdx+1:]
-		c.writeOkay()
-
-		if err := c.commandRouter.ExecuteOnDeviceShellV2(c.connCtx, c.transportSerial, command, c.conn); err != nil {
-			slog.Error("shell v2 command failed", "serial", c.transportSerial, "error", err)
-		}
-
-	default:
-		// Forward unsupported commands (sync:, reboot:, etc.) to the
-		// real ADB server via bidirectional gRPC streaming through device-source.
-		slog.Info("forwarding transport command to device-source", "serial", c.transportSerial, "request", request)
-		if err := c.commandRouter.ForwardToDevice(c.transportSerial, request, c.conn); err != nil {
-			slog.Error("forward failed", "serial", c.transportSerial, "request", request, "error", err)
-			c.writeFail("forward failed: " + err.Error())
-		}
+	// Tunnel all subsequent traffic to the real ADB server through device-source.
+	if err := c.commandRouter.ForwardToDevice(serial, "", c.conn); err != nil {
+		slog.Error("tunnel failed", "serial", serial, "error", err)
 	}
 }

--- a/internal/proxy/command_router.go
+++ b/internal/proxy/command_router.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // LockResult holds the result of a lock acquisition.
@@ -47,7 +48,15 @@ func NewCommandRouter(orchestratorAddr, deviceSourceAddr, apiKey string, orchest
 	}
 
 	// Device-source connection (local, plaintext)
-	dsConn, err := grpc.NewClient(deviceSourceAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	dsConn, err := grpc.NewClient(deviceSourceAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(64*1024*1024),
+			grpc.MaxCallSendMsgSize(64*1024*1024),
+		),
+		grpc.WithInitialWindowSize(16*1024*1024),
+		grpc.WithInitialConnWindowSize(16*1024*1024),
+	)
 	if err != nil {
 		orchConn.Close()
 		return nil, err
@@ -73,85 +82,6 @@ func (r *CommandRouter) ctxWithTimeout(d time.Duration) (context.Context, contex
 	return context.WithTimeout(ctx, d)
 }
 
-// ADB operations — go directly to the device-source
-
-func (r *CommandRouter) ExecuteOnDevice(ctx context.Context, serial, command string, onOutput func([]byte) error) error {
-	req := &dspb.DeviceCommand{
-		Serial:  serial,
-		Command: command,
-	}
-	stream, err := r.dsClient.ExecOnDevice(ctx, req)
-	if err != nil {
-		return err
-	}
-	for {
-		result, err := stream.Recv()
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if result.Stdout != "" {
-			if err := onOutput([]byte(result.Stdout)); err != nil {
-				return err
-			}
-		}
-		if result.Stderr != "" {
-			if err := onOutput([]byte(result.Stderr)); err != nil {
-				return err
-			}
-		}
-	}
-}
-
-// ExecuteOnDeviceShellV2 runs a command via ExecOnDevice and writes the output
-// using shell v2 binary framing (stdout/stderr/exit packets). This lets ddmlib
-// clients that send shell,v2 requests get properly framed responses without
-// going through the fragile ForwardToDevice bidirectional tunnel.
-//
-// Note: stdin (shell v2 ID 0) is not supported — the underlying ExecOnDevice
-// RPC runs a non-interactive "adb shell <cmd>" subprocess with no stdin pipe.
-// This is fine for the non-interactive commands ddmlib sends (pm install, etc.).
-func (r *CommandRouter) ExecuteOnDeviceShellV2(ctx context.Context, serial, command string, conn net.Conn) error {
-	req := &dspb.DeviceCommand{
-		Serial:  serial,
-		Command: command,
-	}
-	stream, err := r.dsClient.ExecOnDevice(ctx, req)
-	if err != nil {
-		return err
-	}
-	var exitCode int32
-	for {
-		result, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		if result.Stdout != "" {
-			if err := WriteShellV2Packet(conn, shellV2Stdout, []byte(result.Stdout)); err != nil {
-				return err
-			}
-		}
-		if result.Stderr != "" {
-			if err := WriteShellV2Packet(conn, shellV2Stderr, []byte(result.Stderr)); err != nil {
-				return err
-			}
-		}
-		// device-source sends exit code as the final message (after all
-		// stdout/stderr has drained), so only capture it from messages
-		// that carry no output to avoid overwriting with protobuf's
-		// default zero from intermediate messages.
-		if result.Stdout == "" && result.Stderr == "" {
-			exitCode = result.ExitCode
-		}
-	}
-	return WriteShellV2Packet(conn, shellV2Exit, []byte{byte(exitCode)})
-}
-
 // ForwardToDevice relays raw bytes between a TCP connection and the device-source's ForwardToDevice gRPC stream.
 func (r *CommandRouter) ForwardToDevice(serial, command string, conn net.Conn) error {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -175,16 +105,19 @@ func (r *CommandRouter) ForwardToDevice(serial, command string, conn net.Conn) e
 		return err
 	}
 
-	done := make(chan error, 2)
+	done := make(chan error, 1)
 
-	// TCP → gRPC
+	// TCP → gRPC (request direction — half-close aware)
 	go func() {
 		buf := make([]byte, 32768)
 		for {
 			n, err := conn.Read(buf)
 			if err != nil {
 				stream.CloseSend()
-				done <- err
+				if err != io.EOF {
+					// Real error — cancel to unblock response direction
+					cancel()
+				}
 				return
 			}
 			data := make([]byte, n)
@@ -192,13 +125,13 @@ func (r *CommandRouter) ForwardToDevice(serial, command string, conn net.Conn) e
 			if err := stream.Send(&dspb.ForwardData{
 				Payload: &dspb.ForwardData_Data{Data: data},
 			}); err != nil {
-				done <- err
+				cancel()
 				return
 			}
 		}
 	}()
 
-	// gRPC → TCP
+	// gRPC → TCP (response direction — drives teardown)
 	go func() {
 		for {
 			resp, err := stream.Recv()
@@ -215,12 +148,10 @@ func (r *CommandRouter) ForwardToDevice(serial, command string, conn net.Conn) e
 		}
 	}()
 
-	// Wait for first direction to finish, then tear down the other.
-	// cancel() unblocks gRPC Recv/Send; SetReadDeadline unblocks TCP Read.
+	// Wait for the response direction to finish, then tear down.
 	err = <-done
 	cancel()
 	conn.SetReadDeadline(time.Now())
-	<-done
 
 	if err == io.EOF {
 		return nil
@@ -228,10 +159,25 @@ func (r *CommandRouter) ForwardToDevice(serial, command string, conn net.Conn) e
 	return err
 }
 
+// Device-source operations — device discovery
+
+func (r *CommandRouter) GetDevicesFromSource() (*dspb.Devices, error) {
+	ctx, cancel := r.ctxWithTimeout(10 * time.Second)
+	defer cancel()
+	return r.dsClient.GetDevices(ctx, &emptypb.Empty{})
+}
+
 // Orchestrator operations — lock management only
 
 func (r *CommandRouter) ListDevices() (*pb.DeviceList, error) {
 	return r.orchClient.ListDevices(r.ctx(), &pb.ListDevicesRequest{})
+}
+
+func (r *CommandRouter) ReportDevices(devices []*pb.DeviceInfo) error {
+	ctx, cancel := r.ctxWithTimeout(10 * time.Second)
+	defer cancel()
+	_, err := r.orchClient.ReportDevices(ctx, &pb.ReportDevicesRequest{Devices: devices})
+	return err
 }
 
 func (r *CommandRouter) AcquireLock(serials map[string]struct{}, deadlineMinutes int64) (*LockResult, error) {

--- a/internal/proxy/device_tracker.go
+++ b/internal/proxy/device_tracker.go
@@ -9,26 +9,34 @@ import (
 	pb "github.com/compscidr/sair/proto/orchestrator"
 )
 
-// DeviceListTracker polls the orchestrator for the current device list and caches it.
-// Also assigns stable transport_id values for each device serial.
+// DeviceListTracker maintains the device list reported by device-sources.
+// Device-sources push their device lists via the proxy's HTTP API; this
+// tracker caches them and periodically reports to the orchestrator for
+// lock management. Also assigns stable transport_id values per serial.
 type DeviceListTracker struct {
-	commandRouter  *CommandRouter
-	pollIntervalMs int64
+	commandRouter *CommandRouter
+
+	mu      sync.Mutex
+	sources map[string]sourceEntry // sourceAddr -> devices
 
 	devices       atomic.Value // []*pb.DeviceInfo
 	transportIDs  sync.Map     // serial -> int
 	nextTransport atomic.Int32
 
-	stopCh chan struct{}
+	reportInterval time.Duration
+	stopCh         chan struct{}
 }
 
-func NewDeviceListTracker(commandRouter *CommandRouter, pollIntervalMs int64) *DeviceListTracker {
-	if pollIntervalMs <= 0 {
-		pollIntervalMs = 5000
-	}
+type sourceEntry struct {
+	devices  []*pb.DeviceInfo
+	lastSeen time.Time
+}
+
+func NewDeviceListTracker(commandRouter *CommandRouter) *DeviceListTracker {
 	t := &DeviceListTracker{
 		commandRouter:  commandRouter,
-		pollIntervalMs: pollIntervalMs,
+		sources:        make(map[string]sourceEntry),
+		reportInterval: 10 * time.Second,
 		stopCh:         make(chan struct{}),
 	}
 	t.devices.Store([]*pb.DeviceInfo{})
@@ -37,20 +45,28 @@ func NewDeviceListTracker(commandRouter *CommandRouter, pollIntervalMs int64) *D
 }
 
 func (t *DeviceListTracker) Start() {
-	t.poll()
-
+	// Periodically report devices to orchestrator and reap stale sources
 	go func() {
-		ticker := time.NewTicker(time.Duration(t.pollIntervalMs) * time.Millisecond)
+		ticker := time.NewTicker(t.reportInterval)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				t.poll()
+				t.reapAndReport()
 			case <-t.stopCh:
 				return
 			}
 		}
 	}()
+}
+
+// UpdateDevices is called when a device-source pushes its device list.
+func (t *DeviceListTracker) UpdateDevices(sourceAddr string, devices []*pb.DeviceInfo) {
+	t.mu.Lock()
+	t.sources[sourceAddr] = sourceEntry{devices: devices, lastSeen: time.Now()}
+	t.mu.Unlock()
+
+	t.rebuild()
 }
 
 func (t *DeviceListTracker) GetDevices() []*pb.DeviceInfo {
@@ -78,26 +94,21 @@ func (t *DeviceListTracker) GetSerialByTransportID(transportID int) string {
 	return result
 }
 
-func (t *DeviceListTracker) poll() {
-	deviceList, err := t.commandRouter.ListDevices()
-	if err != nil {
-		slog.Warn("failed to poll device list", "error", err)
-		return
-	}
-
+// rebuild merges all source device lists into the cached device list.
+func (t *DeviceListTracker) rebuild() {
+	t.mu.Lock()
 	var allDevices []*pb.DeviceInfo
-	for _, source := range deviceList.Sources {
-		if source.Online {
-			allDevices = append(allDevices, source.Devices...)
-		}
+	for _, entry := range t.sources {
+		allDevices = append(allDevices, entry.devices...)
 	}
+	t.mu.Unlock()
 
 	// Assign transport IDs for new devices
 	currentSerials := make(map[string]struct{})
 	for _, device := range allDevices {
 		currentSerials[device.Serial] = struct{}{}
-		if _, loaded := t.transportIDs.LoadOrStore(device.Serial, int(t.nextTransport.Add(1)-1)); loaded {
-			// Already existed
+		if _, loaded := t.transportIDs.Load(device.Serial); !loaded {
+			t.transportIDs.Store(device.Serial, int(t.nextTransport.Add(1)-1))
 		}
 	}
 
@@ -111,6 +122,28 @@ func (t *DeviceListTracker) poll() {
 
 	t.devices.Store(allDevices)
 	slog.Debug("device list updated", "count", len(allDevices))
+}
+
+// reapAndReport removes stale sources and reports current devices to orchestrator.
+func (t *DeviceListTracker) reapAndReport() {
+	staleThreshold := 30 * time.Second
+	now := time.Now()
+
+	t.mu.Lock()
+	for addr, entry := range t.sources {
+		if now.Sub(entry.lastSeen) > staleThreshold {
+			slog.Warn("removing stale device source", "addr", addr)
+			delete(t.sources, addr)
+		}
+	}
+	t.mu.Unlock()
+
+	t.rebuild()
+
+	allDevices := t.GetDevices()
+	if err := t.commandRouter.ReportDevices(allDevices); err != nil {
+		slog.Warn("failed to report devices to orchestrator", "error", err)
+	}
 }
 
 func (t *DeviceListTracker) Stop() {

--- a/internal/proxy/http_api.go
+++ b/internal/proxy/http_api.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	pb "github.com/compscidr/sair/proto/orchestrator"
 )
 
 // HTTPApi provides the HTTP API for the ADB proxy.
@@ -16,21 +18,24 @@ import (
 // device locks. The proxy handles all orchestrator communication and
 // opens scoped ADB ports for per-runner isolation.
 type HTTPApi struct {
-	scopedPortManager *ScopedPortManager
-	apiKey            string
-	server            *http.Server
+	scopedPortManager  *ScopedPortManager
+	deviceListTracker  *DeviceListTracker
+	apiKey             string
+	server             *http.Server
 }
 
-func NewHTTPApi(scopedPortManager *ScopedPortManager, apiKey string, port int, host string) *HTTPApi {
+func NewHTTPApi(scopedPortManager *ScopedPortManager, deviceListTracker *DeviceListTracker, apiKey string, port int, host string) *HTTPApi {
 	api := &HTTPApi{
-		scopedPortManager: scopedPortManager,
-		apiKey:            apiKey,
+		scopedPortManager:  scopedPortManager,
+		deviceListTracker:  deviceListTracker,
+		apiKey:             apiKey,
 	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /acquire", api.handleAcquire)
 	mux.HandleFunc("POST /release", api.handleRelease)
 	mux.HandleFunc("GET /status", api.handleStatus)
+	mux.HandleFunc("POST /internal/devices", api.handleRegisterDevices)
 
 	api.server = &http.Server{
 		Addr:    fmt.Sprintf("%s:%d", host, port),
@@ -152,6 +157,52 @@ func (a *HTTPApi) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"scoped_ports": portInfos})
+}
+
+type deviceReport struct {
+	SourceAddr string       `json:"source_addr"`
+	Devices    []deviceInfo `json:"devices"`
+}
+
+type deviceInfo struct {
+	Serial       string `json:"serial"`
+	Manufacturer string `json:"manufacturer"`
+	Model        string `json:"model"`
+	Sdk          int32  `json:"sdk"`
+	Release      int32  `json:"release"`
+}
+
+func (a *HTTPApi) handleRegisterDevices(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(r) {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid or missing x-api-key header"})
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB limit
+	var report deviceReport
+	if err := json.NewDecoder(r.Body).Decode(&report); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	if report.SourceAddr == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "source_addr required"})
+		return
+	}
+
+	var pbDevices []*pb.DeviceInfo
+	for _, d := range report.Devices {
+		pbDevices = append(pbDevices, &pb.DeviceInfo{
+			Serial:       d.Serial,
+			Manufacturer: d.Manufacturer,
+			Model:        d.Model,
+			Sdk:          d.Sdk,
+			Release:      d.Release,
+		})
+	}
+
+	a.deviceListTracker.UpdateDevices(report.SourceAddr, pbDevices)
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 func writeJSON(w http.ResponseWriter, status int, data any) {

--- a/proto/orchestrator/orchestrator.pb.go
+++ b/proto/orchestrator/orchestrator.pb.go
@@ -1505,6 +1505,86 @@ func (x *LockHeartbeatResponse) GetAlive() bool {
 	return false
 }
 
+type ReportDevicesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Devices       []*DeviceInfo          `protobuf:"bytes,1,rep,name=devices,proto3" json:"devices,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReportDevicesRequest) Reset() {
+	*x = ReportDevicesRequest{}
+	mi := &file_proto_orchestrator_orchestrator_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReportDevicesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReportDevicesRequest) ProtoMessage() {}
+
+func (x *ReportDevicesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_orchestrator_orchestrator_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReportDevicesRequest.ProtoReflect.Descriptor instead.
+func (*ReportDevicesRequest) Descriptor() ([]byte, []int) {
+	return file_proto_orchestrator_orchestrator_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *ReportDevicesRequest) GetDevices() []*DeviceInfo {
+	if x != nil {
+		return x.Devices
+	}
+	return nil
+}
+
+type ReportDevicesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReportDevicesResponse) Reset() {
+	*x = ReportDevicesResponse{}
+	mi := &file_proto_orchestrator_orchestrator_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReportDevicesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReportDevicesResponse) ProtoMessage() {}
+
+func (x *ReportDevicesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_orchestrator_orchestrator_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReportDevicesResponse.ProtoReflect.Descriptor instead.
+func (*ReportDevicesResponse) Descriptor() ([]byte, []int) {
+	return file_proto_orchestrator_orchestrator_proto_rawDescGZIP(), []int{26}
+}
+
 var File_proto_orchestrator_orchestrator_proto protoreflect.FileDescriptor
 
 const file_proto_orchestrator_orchestrator_proto_rawDesc = "" +
@@ -1605,7 +1685,10 @@ const file_proto_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x14LockHeartbeatRequest\x12\x17\n" +
 	"\alock_id\x18\x01 \x01(\tR\x06lockId\"-\n" +
 	"\x15LockHeartbeatResponse\x12\x14\n" +
-	"\x05alive\x18\x01 \x01(\bR\x05alive*d\n" +
+	"\x05alive\x18\x01 \x01(\bR\x05alive\"J\n" +
+	"\x14ReportDevicesRequest\x122\n" +
+	"\adevices\x18\x01 \x03(\v2\x18.orchestrator.DeviceInfoR\adevices\"\x17\n" +
+	"\x15ReportDevicesResponse*d\n" +
 	"\bJobState\x12\x15\n" +
 	"\x11JOB_STATE_UNKNOWN\x10\x00\x12\n" +
 	"\n" +
@@ -1614,7 +1697,7 @@ const file_proto_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\tCOMPLETED\x10\x03\x12\n" +
 	"\n" +
 	"\x06FAILED\x10\x04\x12\r\n" +
-	"\tCANCELLED\x10\x052\xa3\a\n" +
+	"\tCANCELLED\x10\x052\xff\a\n" +
 	"\fOrchestrator\x12B\n" +
 	"\tSubmitJob\x12\x18.orchestrator.JobRequest\x1a\x17.orchestrator.JobOutput\"\x000\x01\x12I\n" +
 	"\fGetJobStatus\x12\x1e.orchestrator.JobStatusRequest\x1a\x17.orchestrator.JobStatus\"\x00\x12K\n" +
@@ -1626,7 +1709,8 @@ const file_proto_orchestrator_orchestrator_proto_rawDesc = "" +
 	"\x10ForwardToSession\x12 .orchestrator.SessionForwardData\x1a .orchestrator.SessionForwardData\"\x00(\x010\x01\x12T\n" +
 	"\vAcquireLock\x12 .orchestrator.AcquireLockRequest\x1a!.orchestrator.AcquireLockResponse\"\x00\x12T\n" +
 	"\vReleaseLock\x12 .orchestrator.ReleaseLockRequest\x1a!.orchestrator.ReleaseLockResponse\"\x00\x12Z\n" +
-	"\rLockHeartbeat\x12\".orchestrator.LockHeartbeatRequest\x1a#.orchestrator.LockHeartbeatResponse\"\x00B.Z,github.com/compscidr/sair/proto/orchestratorb\x06proto3"
+	"\rLockHeartbeat\x12\".orchestrator.LockHeartbeatRequest\x1a#.orchestrator.LockHeartbeatResponse\"\x00\x12Z\n" +
+	"\rReportDevices\x12\".orchestrator.ReportDevicesRequest\x1a#.orchestrator.ReportDevicesResponse\"\x00B.Z,github.com/compscidr/sair/proto/orchestratorb\x06proto3"
 
 var (
 	file_proto_orchestrator_orchestrator_proto_rawDescOnce sync.Once
@@ -1641,7 +1725,7 @@ func file_proto_orchestrator_orchestrator_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_orchestrator_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_proto_orchestrator_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_proto_orchestrator_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_proto_orchestrator_orchestrator_proto_goTypes = []any{
 	(JobState)(0),                 // 0: orchestrator.JobState
 	(*JobRequest)(nil),            // 1: orchestrator.JobRequest
@@ -1669,6 +1753,8 @@ var file_proto_orchestrator_orchestrator_proto_goTypes = []any{
 	(*ReleaseLockResponse)(nil),   // 23: orchestrator.ReleaseLockResponse
 	(*LockHeartbeatRequest)(nil),  // 24: orchestrator.LockHeartbeatRequest
 	(*LockHeartbeatResponse)(nil), // 25: orchestrator.LockHeartbeatResponse
+	(*ReportDevicesRequest)(nil),  // 26: orchestrator.ReportDevicesRequest
+	(*ReportDevicesResponse)(nil), // 27: orchestrator.ReportDevicesResponse
 }
 var file_proto_orchestrator_orchestrator_proto_depIdxs = []int32{
 	2,  // 0: orchestrator.JobRequest.requirements:type_name -> orchestrator.DeviceRequirements
@@ -1681,33 +1767,36 @@ var file_proto_orchestrator_orchestrator_proto_depIdxs = []int32{
 	2,  // 7: orchestrator.AcquireDeviceRequest.requirements:type_name -> orchestrator.DeviceRequirements
 	9,  // 8: orchestrator.AcquireDeviceResponse.device:type_name -> orchestrator.DeviceInfo
 	19, // 9: orchestrator.SessionForwardData.setup:type_name -> orchestrator.SessionForwardSetup
-	1,  // 10: orchestrator.Orchestrator.SubmitJob:input_type -> orchestrator.JobRequest
-	4,  // 11: orchestrator.Orchestrator.GetJobStatus:input_type -> orchestrator.JobStatusRequest
-	6,  // 12: orchestrator.Orchestrator.ListDevices:input_type -> orchestrator.ListDevicesRequest
-	10, // 13: orchestrator.Orchestrator.Ping:input_type -> orchestrator.PingRequest
-	12, // 14: orchestrator.Orchestrator.AcquireDevice:input_type -> orchestrator.AcquireDeviceRequest
-	14, // 15: orchestrator.Orchestrator.ExecuteOnSession:input_type -> orchestrator.SessionCommand
-	16, // 16: orchestrator.Orchestrator.ReleaseDevice:input_type -> orchestrator.ReleaseDeviceRequest
-	18, // 17: orchestrator.Orchestrator.ForwardToSession:input_type -> orchestrator.SessionForwardData
-	20, // 18: orchestrator.Orchestrator.AcquireLock:input_type -> orchestrator.AcquireLockRequest
-	22, // 19: orchestrator.Orchestrator.ReleaseLock:input_type -> orchestrator.ReleaseLockRequest
-	24, // 20: orchestrator.Orchestrator.LockHeartbeat:input_type -> orchestrator.LockHeartbeatRequest
-	3,  // 21: orchestrator.Orchestrator.SubmitJob:output_type -> orchestrator.JobOutput
-	5,  // 22: orchestrator.Orchestrator.GetJobStatus:output_type -> orchestrator.JobStatus
-	7,  // 23: orchestrator.Orchestrator.ListDevices:output_type -> orchestrator.DeviceList
-	11, // 24: orchestrator.Orchestrator.Ping:output_type -> orchestrator.PingResponse
-	13, // 25: orchestrator.Orchestrator.AcquireDevice:output_type -> orchestrator.AcquireDeviceResponse
-	15, // 26: orchestrator.Orchestrator.ExecuteOnSession:output_type -> orchestrator.SessionCommandResult
-	17, // 27: orchestrator.Orchestrator.ReleaseDevice:output_type -> orchestrator.ReleaseDeviceResponse
-	18, // 28: orchestrator.Orchestrator.ForwardToSession:output_type -> orchestrator.SessionForwardData
-	21, // 29: orchestrator.Orchestrator.AcquireLock:output_type -> orchestrator.AcquireLockResponse
-	23, // 30: orchestrator.Orchestrator.ReleaseLock:output_type -> orchestrator.ReleaseLockResponse
-	25, // 31: orchestrator.Orchestrator.LockHeartbeat:output_type -> orchestrator.LockHeartbeatResponse
-	21, // [21:32] is the sub-list for method output_type
-	10, // [10:21] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	9,  // 10: orchestrator.ReportDevicesRequest.devices:type_name -> orchestrator.DeviceInfo
+	1,  // 11: orchestrator.Orchestrator.SubmitJob:input_type -> orchestrator.JobRequest
+	4,  // 12: orchestrator.Orchestrator.GetJobStatus:input_type -> orchestrator.JobStatusRequest
+	6,  // 13: orchestrator.Orchestrator.ListDevices:input_type -> orchestrator.ListDevicesRequest
+	10, // 14: orchestrator.Orchestrator.Ping:input_type -> orchestrator.PingRequest
+	12, // 15: orchestrator.Orchestrator.AcquireDevice:input_type -> orchestrator.AcquireDeviceRequest
+	14, // 16: orchestrator.Orchestrator.ExecuteOnSession:input_type -> orchestrator.SessionCommand
+	16, // 17: orchestrator.Orchestrator.ReleaseDevice:input_type -> orchestrator.ReleaseDeviceRequest
+	18, // 18: orchestrator.Orchestrator.ForwardToSession:input_type -> orchestrator.SessionForwardData
+	20, // 19: orchestrator.Orchestrator.AcquireLock:input_type -> orchestrator.AcquireLockRequest
+	22, // 20: orchestrator.Orchestrator.ReleaseLock:input_type -> orchestrator.ReleaseLockRequest
+	24, // 21: orchestrator.Orchestrator.LockHeartbeat:input_type -> orchestrator.LockHeartbeatRequest
+	26, // 22: orchestrator.Orchestrator.ReportDevices:input_type -> orchestrator.ReportDevicesRequest
+	3,  // 23: orchestrator.Orchestrator.SubmitJob:output_type -> orchestrator.JobOutput
+	5,  // 24: orchestrator.Orchestrator.GetJobStatus:output_type -> orchestrator.JobStatus
+	7,  // 25: orchestrator.Orchestrator.ListDevices:output_type -> orchestrator.DeviceList
+	11, // 26: orchestrator.Orchestrator.Ping:output_type -> orchestrator.PingResponse
+	13, // 27: orchestrator.Orchestrator.AcquireDevice:output_type -> orchestrator.AcquireDeviceResponse
+	15, // 28: orchestrator.Orchestrator.ExecuteOnSession:output_type -> orchestrator.SessionCommandResult
+	17, // 29: orchestrator.Orchestrator.ReleaseDevice:output_type -> orchestrator.ReleaseDeviceResponse
+	18, // 30: orchestrator.Orchestrator.ForwardToSession:output_type -> orchestrator.SessionForwardData
+	21, // 31: orchestrator.Orchestrator.AcquireLock:output_type -> orchestrator.AcquireLockResponse
+	23, // 32: orchestrator.Orchestrator.ReleaseLock:output_type -> orchestrator.ReleaseLockResponse
+	25, // 33: orchestrator.Orchestrator.LockHeartbeat:output_type -> orchestrator.LockHeartbeatResponse
+	27, // 34: orchestrator.Orchestrator.ReportDevices:output_type -> orchestrator.ReportDevicesResponse
+	23, // [23:35] is the sub-list for method output_type
+	11, // [11:23] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_proto_orchestrator_orchestrator_proto_init() }
@@ -1725,7 +1814,7 @@ func file_proto_orchestrator_orchestrator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_orchestrator_orchestrator_proto_rawDesc), len(file_proto_orchestrator_orchestrator_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   25,
+			NumMessages:   27,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/orchestrator/orchestrator.proto
+++ b/proto/orchestrator/orchestrator.proto
@@ -16,6 +16,7 @@ service Orchestrator {
   rpc AcquireLock(AcquireLockRequest) returns (AcquireLockResponse) {}
   rpc ReleaseLock(ReleaseLockRequest) returns (ReleaseLockResponse) {}
   rpc LockHeartbeat(LockHeartbeatRequest) returns (LockHeartbeatResponse) {}
+  rpc ReportDevices(ReportDevicesRequest) returns (ReportDevicesResponse) {}
 }
 
 message JobRequest {
@@ -167,3 +168,11 @@ message LockHeartbeatRequest {
 message LockHeartbeatResponse {
   bool alive = 1;
 }
+
+// ReportDevicesRequest is sent by the proxy to report its current device list.
+// The busy field in DeviceInfo is ignored; busy state is managed by the orchestrator.
+message ReportDevicesRequest {
+  repeated DeviceInfo devices = 1;
+}
+
+message ReportDevicesResponse {}

--- a/proto/orchestrator/orchestrator_grpc.pb.go
+++ b/proto/orchestrator/orchestrator_grpc.pb.go
@@ -30,6 +30,7 @@ const (
 	Orchestrator_AcquireLock_FullMethodName      = "/orchestrator.Orchestrator/AcquireLock"
 	Orchestrator_ReleaseLock_FullMethodName      = "/orchestrator.Orchestrator/ReleaseLock"
 	Orchestrator_LockHeartbeat_FullMethodName    = "/orchestrator.Orchestrator/LockHeartbeat"
+	Orchestrator_ReportDevices_FullMethodName    = "/orchestrator.Orchestrator/ReportDevices"
 )
 
 // OrchestratorClient is the client API for Orchestrator service.
@@ -47,6 +48,7 @@ type OrchestratorClient interface {
 	AcquireLock(ctx context.Context, in *AcquireLockRequest, opts ...grpc.CallOption) (*AcquireLockResponse, error)
 	ReleaseLock(ctx context.Context, in *ReleaseLockRequest, opts ...grpc.CallOption) (*ReleaseLockResponse, error)
 	LockHeartbeat(ctx context.Context, in *LockHeartbeatRequest, opts ...grpc.CallOption) (*LockHeartbeatResponse, error)
+	ReportDevices(ctx context.Context, in *ReportDevicesRequest, opts ...grpc.CallOption) (*ReportDevicesResponse, error)
 }
 
 type orchestratorClient struct {
@@ -188,6 +190,16 @@ func (c *orchestratorClient) LockHeartbeat(ctx context.Context, in *LockHeartbea
 	return out, nil
 }
 
+func (c *orchestratorClient) ReportDevices(ctx context.Context, in *ReportDevicesRequest, opts ...grpc.CallOption) (*ReportDevicesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReportDevicesResponse)
+	err := c.cc.Invoke(ctx, Orchestrator_ReportDevices_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // OrchestratorServer is the server API for Orchestrator service.
 // All implementations must embed UnimplementedOrchestratorServer
 // for forward compatibility.
@@ -203,6 +215,7 @@ type OrchestratorServer interface {
 	AcquireLock(context.Context, *AcquireLockRequest) (*AcquireLockResponse, error)
 	ReleaseLock(context.Context, *ReleaseLockRequest) (*ReleaseLockResponse, error)
 	LockHeartbeat(context.Context, *LockHeartbeatRequest) (*LockHeartbeatResponse, error)
+	ReportDevices(context.Context, *ReportDevicesRequest) (*ReportDevicesResponse, error)
 	mustEmbedUnimplementedOrchestratorServer()
 }
 
@@ -245,6 +258,9 @@ func (UnimplementedOrchestratorServer) ReleaseLock(context.Context, *ReleaseLock
 }
 func (UnimplementedOrchestratorServer) LockHeartbeat(context.Context, *LockHeartbeatRequest) (*LockHeartbeatResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method LockHeartbeat not implemented")
+}
+func (UnimplementedOrchestratorServer) ReportDevices(context.Context, *ReportDevicesRequest) (*ReportDevicesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ReportDevices not implemented")
 }
 func (UnimplementedOrchestratorServer) mustEmbedUnimplementedOrchestratorServer() {}
 func (UnimplementedOrchestratorServer) testEmbeddedByValue()                      {}
@@ -440,6 +456,24 @@ func _Orchestrator_LockHeartbeat_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Orchestrator_ReportDevices_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReportDevicesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OrchestratorServer).ReportDevices(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Orchestrator_ReportDevices_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OrchestratorServer).ReportDevices(ctx, req.(*ReportDevicesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Orchestrator_ServiceDesc is the grpc.ServiceDesc for Orchestrator service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -478,6 +512,10 @@ var Orchestrator_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "LockHeartbeat",
 			Handler:    _Orchestrator_LockHeartbeat_Handler,
+		},
+		{
+			MethodName: "ReportDevices",
+			Handler:    _Orchestrator_ReportDevices_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{


### PR DESCRIPTION
## Summary
- PR #13 ("Fix architecture: transparent ADB tunnel and push-based device discovery") was accidentally merged into `fix/remove-abb-exec-feature` instead of `main`
- This PR brings those changes to main: push-based device discovery, transparent ADB tunnel, `ReportDevices` gRPC RPC, and related fixes
- Needed to unblock the orchestrator repo build which depends on the `ReportDevices` proto definition

## Test plan
- [x] These changes already passed review in PR #13
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)