### PR TITLE
Add --count to acquire any N free devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,12 @@ this repo's `tools/` directory to `PATH`.
 **Acquire** a device lock (blocks until devices are available):
 
 ```bash
-eval $(sair-acquire)
+eval $(sair-acquire)            # all devices
+eval $(sair-acquire --count 1)  # any one free device
 ```
+
+CI jobs that only need one phone should use `--count 1`, so the rest of the
+pool stays available to other jobs.
 
 After eval, these environment variables are set:
 
@@ -170,6 +174,9 @@ Common options:
 # Acquire specific device(s)
 eval $(sair-acquire --serial DEVICE_A)
 eval $(sair-acquire --serial DEVICE_A,DEVICE_B)
+
+# Acquire any N free devices (mutually exclusive with --serial)
+eval $(sair-acquire --count 2)
 
 # Point to a remote proxy
 eval $(sair-acquire --url http://proxy-host:8550 --api-key my-key)
@@ -290,13 +297,14 @@ jobs:
           SAIR_PROXY_URL: ${{ vars.SAIR_PROXY_URL }}
           SAIR_API_KEY: ${{ secrets.SAIR_API_KEY }}
         run: |
-          ACQUIRE_OUTPUT=$(sair/tools/sair-acquire)
+          ACQUIRE_OUTPUT=$(sair/tools/sair-acquire --count 1)
           eval "$ACQUIRE_OUTPUT"
           # Re-export for subsequent steps
           echo "SAIR_LOCK_ID=$SAIR_LOCK_ID" >> "$GITHUB_ENV"
           echo "SAIR_SERIALS=$SAIR_SERIALS" >> "$GITHUB_ENV"
           echo "SAIR_PROXY_URL=$SAIR_PROXY_URL" >> "$GITHUB_ENV"
           echo "ANDROID_ADB_SERVER_PORT=$ANDROID_ADB_SERVER_PORT" >> "$GITHUB_ENV"
+          echo "ANDROID_SERIAL=$ANDROID_SERIAL" >> "$GITHUB_ENV"
 
       - name: Run connected tests
         run: ./gradlew connectedCheck
@@ -312,6 +320,9 @@ Key points about the workflow:
 
 - `sair-acquire` blocks until a device is available, so jobs queue naturally
   when all devices are busy.
+- `--count 1` locks a single free device instead of the whole pool, leaving the
+  other devices for concurrent jobs. It also sets `ANDROID_SERIAL`, so Gradle
+  targets that one device.
 - `ANDROID_ADB_SERVER_PORT` tells stock `adb` to connect to the proxy's scoped
   port, which only exposes the locked devices.
 - `sair-release` is in an `if: always()` step so the lock is freed even when

--- a/internal/proxy/command_router.go
+++ b/internal/proxy/command_router.go
@@ -214,6 +214,12 @@ func (r *CommandRouter) ReportDevices(devices []*pb.DeviceInfo) error {
 // specific devices, or count to request that many arbitrary free devices.
 // Passing neither locks every device in the tenant's pool.
 func (r *CommandRouter) AcquireLock(serials map[string]struct{}, count int32, deadlineMinutes int64, repo string) (*LockResult, error) {
+	if count < 0 {
+		return nil, fmt.Errorf("count must not be negative: %d", count)
+	}
+	if count > 0 && len(serials) > 0 {
+		return nil, fmt.Errorf("count and serials are mutually exclusive")
+	}
 	if deadlineMinutes <= 0 {
 		deadlineMinutes = 30
 	}

--- a/internal/proxy/command_router.go
+++ b/internal/proxy/command_router.go
@@ -210,14 +210,17 @@ func (r *CommandRouter) ReportDevices(devices []*pb.DeviceInfo) error {
 	return err
 }
 
-func (r *CommandRouter) AcquireLock(serials map[string]struct{}, deadlineMinutes int64, repo string) (*LockResult, error) {
+// AcquireLock asks the orchestrator for a lock. Pass serials to request
+// specific devices, or count to request that many arbitrary free devices.
+// Passing neither locks every device in the tenant's pool.
+func (r *CommandRouter) AcquireLock(serials map[string]struct{}, count int32, deadlineMinutes int64, repo string) (*LockResult, error) {
 	if deadlineMinutes <= 0 {
 		deadlineMinutes = 30
 	}
 	ctx, cancel := r.ctxWithTimeout(time.Duration(deadlineMinutes) * time.Minute)
 	defer cancel()
 
-	req := &pb.AcquireLockRequest{Repo: repo}
+	req := &pb.AcquireLockRequest{Repo: repo, Count: count}
 	for s := range serials {
 		req.Serials = append(req.Serials, s)
 	}

--- a/internal/proxy/command_router_test.go
+++ b/internal/proxy/command_router_test.go
@@ -63,3 +63,28 @@ func TestAcquireLockWithSerialsSendsNoCount(t *testing.T) {
 		t.Errorf("got serials %v, want [DEVICE_A]", fake.lastAcquire.Serials)
 	}
 }
+
+func TestAcquireLockRejectsInvalidCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		serials map[string]struct{}
+		count   int32
+	}{
+		{"negative count", nil, -1},
+		{"count with serials", map[string]struct{}{"DEVICE_A": {}}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeOrchClient{}
+			router := &CommandRouter{orchClient: fake, apiKey: "test-key"}
+
+			if _, err := router.AcquireLock(tt.serials, tt.count, 30, ""); err == nil {
+				t.Error("expected an error")
+			}
+			if fake.lastAcquire != nil {
+				t.Error("invalid request was sent to the orchestrator")
+			}
+		})
+	}
+}

--- a/internal/proxy/command_router_test.go
+++ b/internal/proxy/command_router_test.go
@@ -1,0 +1,65 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/compscidr/sair/proto/orchestrator"
+	"google.golang.org/grpc"
+)
+
+// fakeOrchClient records the last AcquireLock request and returns a canned
+// response. The embedded interface leaves the unused RPCs unimplemented.
+type fakeOrchClient struct {
+	pb.OrchestratorClient
+	lastAcquire *pb.AcquireLockRequest
+	resp        *pb.AcquireLockResponse
+}
+
+func (f *fakeOrchClient) AcquireLock(ctx context.Context, in *pb.AcquireLockRequest, opts ...grpc.CallOption) (*pb.AcquireLockResponse, error) {
+	f.lastAcquire = in
+	return f.resp, nil
+}
+
+func TestAcquireLockSendsCount(t *testing.T) {
+	fake := &fakeOrchClient{
+		resp: &pb.AcquireLockResponse{LockId: "lock-1", Serials: []string{"DEVICE_A", "DEVICE_B"}},
+	}
+	router := &CommandRouter{orchClient: fake, apiKey: "test-key"}
+
+	result, err := router.AcquireLock(nil, 2, 30, "compscidr/hello-kotlin-android")
+	if err != nil {
+		t.Fatalf("AcquireLock returned error: %v", err)
+	}
+
+	if fake.lastAcquire.Count != 2 {
+		t.Errorf("got count %d, want 2", fake.lastAcquire.Count)
+	}
+	if len(fake.lastAcquire.Serials) != 0 {
+		t.Errorf("got serials %v, want none", fake.lastAcquire.Serials)
+	}
+	if result.LockID != "lock-1" {
+		t.Errorf("got lock id %q, want %q", result.LockID, "lock-1")
+	}
+	if len(result.Serials) != 2 {
+		t.Errorf("got %d serials, want 2", len(result.Serials))
+	}
+}
+
+func TestAcquireLockWithSerialsSendsNoCount(t *testing.T) {
+	fake := &fakeOrchClient{
+		resp: &pb.AcquireLockResponse{LockId: "lock-2", Serials: []string{"DEVICE_A"}},
+	}
+	router := &CommandRouter{orchClient: fake, apiKey: "test-key"}
+
+	if _, err := router.AcquireLock(map[string]struct{}{"DEVICE_A": {}}, 0, 30, ""); err != nil {
+		t.Fatalf("AcquireLock returned error: %v", err)
+	}
+
+	if fake.lastAcquire.Count != 0 {
+		t.Errorf("got count %d, want 0", fake.lastAcquire.Count)
+	}
+	if len(fake.lastAcquire.Serials) != 1 || fake.lastAcquire.Serials[0] != "DEVICE_A" {
+		t.Errorf("got serials %v, want [DEVICE_A]", fake.lastAcquire.Serials)
+	}
+}

--- a/internal/proxy/http_api.go
+++ b/internal/proxy/http_api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -87,8 +88,24 @@ func (a *HTTPApi) handleAcquire(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// count requests that many arbitrary free devices instead of named ones,
+	// so it is mutually exclusive with serial. Omitted (or 0) means "all".
+	var count int64
+	if countParam := r.URL.Query().Get("count"); countParam != "" {
+		parsed, err := strconv.ParseInt(countParam, 10, 32)
+		if err != nil || parsed < 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "count parameter must be a non-negative integer"})
+			return
+		}
+		if parsed > 0 && requestedSerials != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "count and serial parameters are mutually exclusive"})
+			return
+		}
+		count = parsed
+	}
+
 	repo := r.URL.Query().Get("repo")
-	sp, err := a.scopedPortManager.Acquire(requestedSerials, repo)
+	sp, err := a.scopedPortManager.Acquire(requestedSerials, int32(count), repo)
 	if err != nil {
 		slog.Error("failed to acquire", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})

--- a/internal/proxy/http_api_test.go
+++ b/internal/proxy/http_api_test.go
@@ -86,7 +86,9 @@ func TestHTTPApiAcquireCountValidation(t *testing.T) {
 			}
 
 			var resp map[string]string
-			json.Unmarshal(w.Body.Bytes(), &resp)
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("response body is not JSON (%v): %s", err, w.Body.String())
+			}
 			if resp["error"] != tt.wantError {
 				t.Errorf("got error %q, want %q", resp["error"], tt.wantError)
 			}

--- a/internal/proxy/http_api_test.go
+++ b/internal/proxy/http_api_test.go
@@ -56,6 +56,44 @@ func TestHTTPApiAuthRequired(t *testing.T) {
 	}
 }
 
+func TestHTTPApiAcquireCountValidation(t *testing.T) {
+	// Validation happens before the scoped port manager is touched, so a bare
+	// HTTPApi is enough to exercise these paths.
+	api := &HTTPApi{
+		apiKey: "test-key",
+	}
+
+	tests := []struct {
+		name      string
+		query     string
+		wantError string
+	}{
+		{"non-numeric count", "?count=abc", "count parameter must be a non-negative integer"},
+		{"negative count", "?count=-1", "count parameter must be a non-negative integer"},
+		{"count with serial", "?count=1&serial=DEVICE_A", "count and serial parameters are mutually exclusive"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/acquire"+tt.query, nil)
+			req.Header.Set("x-api-key", "test-key")
+			w := httptest.NewRecorder()
+
+			api.handleAcquire(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("got status %d, want %d", w.Code, http.StatusBadRequest)
+			}
+
+			var resp map[string]string
+			json.Unmarshal(w.Body.Bytes(), &resp)
+			if resp["error"] != tt.wantError {
+				t.Errorf("got error %q, want %q", resp["error"], tt.wantError)
+			}
+		})
+	}
+}
+
 func TestHTTPApiReleaseMissingLockID(t *testing.T) {
 	api := &HTTPApi{
 		apiKey: "test-key",

--- a/internal/proxy/scoped_port.go
+++ b/internal/proxy/scoped_port.go
@@ -50,8 +50,11 @@ func NewScopedPortManager(
 
 // Acquire acquires a lock from the orchestrator (via gRPC) and opens a scoped ADB port.
 // Blocks until the orchestrator grants the lock.
-func (m *ScopedPortManager) Acquire(requestedSerials map[string]struct{}, repo string) (*ScopedPort, error) {
-	result, err := m.commandRouter.AcquireLock(requestedSerials, 30, repo)
+//
+// Pass requestedSerials for specific devices, or count for that many arbitrary
+// free devices. Passing neither locks every device in the tenant's pool.
+func (m *ScopedPortManager) Acquire(requestedSerials map[string]struct{}, count int32, repo string) (*ScopedPort, error) {
+	result, err := m.commandRouter.AcquireLock(requestedSerials, count, 30, repo)
 	if err != nil {
 		return nil, err
 	}

--- a/proto/orchestrator/orchestrator.proto
+++ b/proto/orchestrator/orchestrator.proto
@@ -36,9 +36,13 @@ message DeviceInfo {
   bool busy = 6;
 }
 
+// A lock request either names the devices it wants (serials) or asks for a
+// number of arbitrary free devices (count). Setting both is invalid; setting
+// neither means "all devices in the tenant's pool".
 message AcquireLockRequest {
   repeated string serials = 1;
   string repo = 2;
+  int32 count = 3;
 }
 
 message AcquireLockResponse {

--- a/tools/sair-acquire
+++ b/tools/sair-acquire
@@ -76,8 +76,10 @@ if [[ -n "$COUNT" ]]; then
         echo "sair-acquire: ERROR: --count and --serial are mutually exclusive" >&2
         exit 1
     fi
-    if [[ ! "$COUNT" =~ ^[0-9]+$ || "$COUNT" -lt 1 ]]; then
-        echo "sair-acquire: ERROR: --count must be a positive integer (got '${COUNT}')" >&2
+    # Bounded by the wire type (int32) so oversized values fail here rather
+    # than in the proxy — and so the comparisons below stay in range.
+    if [[ ! "$COUNT" =~ ^[0-9]{1,10}$ ]] || [[ "$COUNT" -lt 1 || "$COUNT" -gt 2147483647 ]]; then
+        echo "sair-acquire: ERROR: --count must be a positive integer no greater than 2147483647 (got '${COUNT}')" >&2
         exit 1
     fi
 fi

--- a/tools/sair-acquire
+++ b/tools/sair-acquire
@@ -9,6 +9,8 @@
 #
 # Usage:
 #   eval $(sair-acquire)                          # lock all devices
+#   eval $(sair-acquire --count 1)                # lock any one free device
+#   eval $(sair-acquire --count 2)                # lock any two free devices
 #   eval $(sair-acquire --serial DEVICE_A)        # lock specific device
 #   eval $(sair-acquire --serial DEVICE_A,DEVICE_B)  # lock multiple devices
 #
@@ -28,12 +30,17 @@ set -euo pipefail
 PROXY_URL="${SAIR_PROXY_URL:-http://localhost:8550}"
 API_KEY="${SAIR_API_KEY:-dev-key-123}"
 SERIAL=""
+COUNT=""
 
 # Parse flags
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --serial)
             SERIAL="$2"
+            shift 2
+            ;;
+        --count)
+            COUNT="$2"
             shift 2
             ;;
         --url)
@@ -45,13 +52,14 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --help|-h)
-            echo "Usage: eval \$(sair-acquire [--serial SERIAL[,SERIAL...]] [--url URL] [--api-key KEY])" >&2
+            echo "Usage: eval \$(sair-acquire [--serial SERIAL[,SERIAL...]] [--count N] [--url URL] [--api-key KEY])" >&2
             echo "" >&2
             echo "Acquires a device lock via the SAIR ADB proxy." >&2
             echo "Blocks until devices are available." >&2
             echo "" >&2
             echo "Options:" >&2
             echo "  --serial SERIAL   Specific device(s) to lock (comma-separated, default: all)" >&2
+            echo "  --count N         Lock any N free devices (mutually exclusive with --serial)" >&2
             echo "  --url URL         Proxy API URL (default: \$SAIR_PROXY_URL or http://localhost:8550)" >&2
             echo "  --api-key KEY     API key (default: \$SAIR_API_KEY or dev-key-123)" >&2
             exit 0
@@ -63,12 +71,25 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [[ -n "$COUNT" ]]; then
+    if [[ -n "$SERIAL" ]]; then
+        echo "sair-acquire: ERROR: --count and --serial are mutually exclusive" >&2
+        exit 1
+    fi
+    if [[ ! "$COUNT" =~ ^[0-9]+$ || "$COUNT" -lt 1 ]]; then
+        echo "sair-acquire: ERROR: --count must be a positive integer (got '${COUNT}')" >&2
+        exit 1
+    fi
+fi
+
 # Build acquire URL
 ACQUIRE_URL="${PROXY_URL}/acquire"
 
 echo "sair-acquire: requesting lock from proxy at ${PROXY_URL}..." >&2
 if [[ -n "$SERIAL" ]]; then
     echo "sair-acquire: devices: ${SERIAL}" >&2
+elif [[ -n "$COUNT" ]]; then
+    echo "sair-acquire: devices: any ${COUNT}" >&2
 else
     echo "sair-acquire: devices: all" >&2
 fi
@@ -78,6 +99,8 @@ fi
 CURL_ARGS=(-s -X POST -H "x-api-key: ${API_KEY}" -w '\n%{http_code}')
 if [[ -n "$SERIAL" ]]; then
     CURL_ARGS+=(-G --data-urlencode "serial=${SERIAL}")
+elif [[ -n "$COUNT" ]]; then
+    CURL_ARGS+=(-G --data-urlencode "count=${COUNT}")
 fi
 RESPONSE=$(curl "${CURL_ARGS[@]}" "${ACQUIRE_URL}") || {
     echo "sair-acquire: ERROR: failed to contact proxy" >&2


### PR DESCRIPTION
Closes #37.

`sair-acquire` could only lock a named set of serials or the whole pool, so a CI job that needs one phone had to take every device (blocking other jobs) or pin itself to a specific serial (brittle, no fallback). This adds a count-based request: "give me N free devices, I don't care which."

```bash
eval $(sair-acquire --count 1)   # any one free device
eval $(sair-acquire --count 2)   # any two free devices
```

## Changes

- **`tools/sair-acquire`** — `--count N` flag. Rejects `--count` together with `--serial`, and non-positive/non-numeric values, before hitting the network.
- **Proxy HTTP API** — `/acquire?count=N`. `count` must be a non-negative integer and is mutually exclusive with `serial`; omitted or `0` keeps today's "all devices" behaviour.
- **`proto/orchestrator`** — `AcquireLockRequest.count` (field 3). Device selection itself is the orchestrator's job.
- **README** — documents `--count`, and the CI example now uses `--count 1` and propagates `ANDROID_SERIAL` (which `sair-acquire` already exports for single-device locks, so Gradle targets that phone).

## Semantics

Matches what the issue proposed:

| Request | Behaviour |
|---|---|
| neither `serial` nor `count` | all devices in the pool (unchanged) |
| `count=N` | any N free devices, blocking until N are free |
| `count=N` + `serial=...` | rejected (400 / `INVALID_ARGUMENT`) |
| `count` > pool size | rejected by the orchestrator rather than blocking forever |

Attribute filtering (model, SDK level) is out of scope.

## Tests

- `TestAcquireLockSendsCount` / `TestAcquireLockWithSerialsSendsNoCount` — count reaches the orchestrator request; the serial path still sends no count.
- `TestHTTPApiAcquireCountValidation` — non-numeric, negative, and count+serial all return 400 with a specific message.
- Manual: `sair-acquire --count 0|abc|-2` and `--count 1 --serial X` all fail with the expected message; `--help` lists the flag.

`go build ./...`, `go vet ./...`, and `go test -race ./...` pass.

## Merge order

The orchestrator side (free-device selection in `DeviceLockManager`) is a companion PR in `compscidr/sair-ochestrator`. That repo downloads its protos from this repo's `main` at build time (`sairVersion=main`), so **this PR needs to merge first** — until then `--count` is accepted by the proxy but the orchestrator ignores the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)