### PR TITLE
Fail before advertising readiness instead of after

### DIFF
--- a/cmd/sair-proxy/main.go
+++ b/cmd/sair-proxy/main.go
@@ -49,6 +49,14 @@ func main() {
 
 	adbProxy := proxy.NewAdbProxy(port, commandRouter, deviceListTracker)
 
+	// Claim the ADB port before the HTTP API opens: /status is used as a
+	// readiness probe, and must never answer for a proxy that is about to die
+	// because something else already holds this port.
+	if err := adbProxy.Listen(); err != nil {
+		slog.Error("proxy failed", "error", err)
+		os.Exit(1)
+	}
+
 	// Graceful shutdown
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -63,7 +71,10 @@ func main() {
 		os.Exit(0)
 	}()
 
-	httpAPI.Start()
+	if err := httpAPI.Start(); err != nil {
+		slog.Error("HTTP API failed", "error", err)
+		os.Exit(1)
+	}
 	if err := adbProxy.Start(); err != nil {
 		slog.Error("proxy failed", "error", err)
 		os.Exit(1)

--- a/internal/proxy/http_api.go
+++ b/internal/proxy/http_api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -46,13 +47,21 @@ func NewHTTPApi(scopedPortManager *ScopedPortManager, deviceListTracker *DeviceL
 	return api
 }
 
-func (a *HTTPApi) Start() {
+// Start binds the HTTP API port and serves in the background. The bind happens
+// synchronously so a port collision is returned to the caller instead of being
+// logged from a goroutine after "started" has already been announced.
+func (a *HTTPApi) Start() error {
+	ln, err := net.Listen("tcp", a.server.Addr)
+	if err != nil {
+		return err
+	}
 	go func() {
 		slog.Info("proxy HTTP API started", "addr", a.server.Addr)
-		if err := a.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := a.server.Serve(ln); err != nil && err != http.ErrServerClosed {
 			slog.Error("HTTP API failed", "error", err)
 		}
 	}()
+	return nil
 }
 
 func (a *HTTPApi) Stop() {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -34,15 +34,28 @@ func NewAdbProxy(
 	}
 }
 
-func (p *AdbProxy) Start() error {
-	p.deviceListTracker.Start()
-	p.running.Store(true)
-
-	var err error
-	p.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", p.port))
+// Listen binds the ADB port without serving. Callers that advertise readiness
+// elsewhere should Listen first, so a port collision — a stale adb server on
+// 5037, say — kills the process before anything reports the proxy as up.
+func (p *AdbProxy) Listen() error {
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", p.port))
 	if err != nil {
 		return err
 	}
+	p.listener = ln
+	return nil
+}
+
+// Start serves the accept loop, binding first if Listen has not already run.
+func (p *AdbProxy) Start() error {
+	if p.listener == nil {
+		if err := p.Listen(); err != nil {
+			return err
+		}
+	}
+
+	p.deviceListTracker.Start()
+	p.running.Store(true)
 
 	slog.Info("ADB proxy listening (bare — no devices visible)", "port", p.port)
 

--- a/internal/proxy/startup_test.go
+++ b/internal/proxy/startup_test.go
@@ -1,0 +1,54 @@
+package proxy
+
+import (
+	"net"
+	"testing"
+)
+
+// A port collision must surface as an error from Start/Listen, not as a log
+// line from a background goroutine. sair-proxy exits on these, and its /status
+// endpoint is used as a readiness probe: if either bind can fail silently, the
+// probe reports a proxy that is dead or about to die.
+
+func TestHTTPApiStartFailsWhenPortTaken(t *testing.T) {
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not bind blocker: %v", err)
+	}
+	defer blocker.Close()
+
+	port := blocker.Addr().(*net.TCPAddr).Port
+	api := NewHTTPApi(nil, nil, "test-key", port, "127.0.0.1")
+
+	if err := api.Start(); err == nil {
+		api.Stop()
+		t.Fatalf("Start returned nil for already-bound port %d", port)
+	}
+}
+
+func TestAdbProxyListenFailsWhenPortTaken(t *testing.T) {
+	blocker, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("could not bind blocker: %v", err)
+	}
+	defer blocker.Close()
+
+	port := blocker.Addr().(*net.TCPAddr).Port
+	p := NewAdbProxy(port, nil, nil)
+
+	if err := p.Listen(); err == nil {
+		p.listener.Close()
+		t.Fatalf("Listen returned nil for already-bound port %d", port)
+	}
+}
+
+func TestAdbProxyListenThenStopReleasesPort(t *testing.T) {
+	p := NewAdbProxy(0, nil, nil)
+	if err := p.Listen(); err != nil {
+		t.Fatalf("Listen on port 0 failed: %v", err)
+	}
+	if p.listener == nil {
+		t.Fatal("Listen succeeded but left no listener for Start to serve")
+	}
+	p.listener.Close()
+}

--- a/internal/proxy/startup_test.go
+++ b/internal/proxy/startup_test.go
@@ -42,13 +42,29 @@ func TestAdbProxyListenFailsWhenPortTaken(t *testing.T) {
 	}
 }
 
-func TestAdbProxyListenThenStopReleasesPort(t *testing.T) {
-	p := NewAdbProxy(0, nil, nil)
+func TestAdbProxyStopReleasesPort(t *testing.T) {
+	p := NewAdbProxy(0, nil, NewDeviceListTracker(nil))
 	if err := p.Listen(); err != nil {
 		t.Fatalf("Listen on port 0 failed: %v", err)
 	}
 	if p.listener == nil {
 		t.Fatal("Listen succeeded but left no listener for Start to serve")
 	}
-	p.listener.Close()
+	addr := p.listener.Addr().String()
+
+	// main depends on Listen actually claiming the port before the HTTP API
+	// starts answering readiness probes, so a non-nil listener is not enough.
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Listen returned but %s is not accepting connections: %v", addr, err)
+	}
+	conn.Close()
+
+	p.Stop()
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("Stop did not release %s: %v", addr, err)
+	}
+	ln.Close()
 }


### PR DESCRIPTION
Follow-up to the CI failure in compscidr/sair-ochestrator#554, whose proxy log was:

```
INFO  proxy HTTP API started addr=0.0.0.0:8550
ERROR proxy failed error="listen tcp :5037: bind: address already in use"
```

A stale adb server held `:5037`. sair-ochestrator#555 stops that from happening on the runner; this fixes why it was confusing to diagnose, and one silent failure it exposed.

## 1. `HTTPApi.Start` could not fail

`internal/proxy/http_api.go` logged `proxy HTTP API started` *before* `ListenAndServe` had bound anything, swallowed the bind error inside a goroutine, and returned nothing for `main` to check. With `:8550` taken the proxy stayed alive indefinitely with no HTTP API — every client got connection refused from a process that looked healthy.

Now binds synchronously with `net.Listen` and serves the resulting listener, returning the error.

## 2. Readiness was advertised before the bind that fails

`httpAPI.Start()` ran before `adbProxy.Start()` bound `:5037`, so `/status` — which sair-ochestrator polls as a readiness gate — could answer for a process milliseconds from `os.Exit(1)`. In #554 the failure was fast enough that the probe never saw it; a slower interleaving would pass the gate and fail later at `sair-acquire` with the same misleading "failed to contact proxy".

`Listen` is now split out of the accept loop and `main` claims `:5037` before the HTTP API opens. `Start` still binds when `Listen` has not run, so the accept path is unchanged for any other caller.

`sair-device-source` already did this correctly (`cmd/sair-device-source/main.go:42-46`); this brings the proxy in line.

## Verification

Ran both binaries with a port already occupied:

| occupied | old | new |
|---|---|---|
| `:5037` | logs `proxy HTTP API started`, then exits 1 | exits 1, never claims the API is up |
| `:8550` | logs `proxy HTTP API started`, then **runs forever with no HTTP API** | exits 1 |

`internal/proxy/startup_test.go` covers both binds; reverting `Start` to swallow the error fails it. `go vet ./...` and `go test -race ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)