### PR TITLE
Have Renovate run go mod tidy after Go module updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,8 @@
   ],
   "automerge": true,
   "automergeType": "pr",
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "postUpdateOptions": [
+    "gomodTidy"
+  ]
 }


### PR DESCRIPTION
Renovate has **never** regenerated `go.sum` in this repo. Every Go bump lands with `go.mod` changed and `go.sum` stale, which fails CI twice:

- `Check go mod tidy` → `git diff --exit-code` sees the go.sum churn
- `docker-build` → `missing go.sum entry for module providing package google.golang.org/protobuf/proto`

This is the third occurrence. #31 was fixed by hand — its merge commit says *"Renovate updated go.mod but failed to regenerate go.sum checksums"* — and #33 and #39 are both sitting red on it right now.

`postUpdateOptions: ["gomodTidy"]` makes Renovate run `go mod tidy` after updating and commit the result, which is exactly what the CI check compares against.

## Caveat

This may not be the whole story. `go.sum` has never been updated here, including on bumps where plain `go get` would have sufficed without tidy — which hints the artifact update is failing outright rather than merely skipping tidy. The Mend job log at [developer.mend.io/github/compscidr/sair](https://developer.mend.io/github/compscidr/sair) will say which. If artifact updates are failing for another reason (e.g. Renovate's Go toolchain being older than the `go 1.24.0` directive), this needs revisiting.

Validated with `renovate-config-validator`.

## Unrelated, but worth a look

This repo does not use your shared `compscidr/renovate-config` preset, and its inline `"automerge": true` applies to **major** updates too. The shared baseline deliberately excludes those:

> *"Never automerge majors... A breaking major that merges unattended lands on the default branch instead of surfacing as a failing PR."*

Happy to switch this repo to the shared preset separately if you want that policy here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)